### PR TITLE
Fix input path bug in Day 1 scripts

### DIFF
--- a/Day 1/Part1.py
+++ b/Day 1/Part1.py
@@ -1,4 +1,7 @@
-with open('input.txt', 'r') as file:
+import os
+
+input_path = os.path.join(os.path.dirname(__file__), 'input.txt')
+with open(input_path, 'r') as file:
     data = file.read().strip().split('\n\n')
     data = [i.split('\n') for i in data]
 

--- a/Day 1/Part2.py
+++ b/Day 1/Part2.py
@@ -1,4 +1,7 @@
-with open('input.txt', 'r') as file:
+import os
+
+input_path = os.path.join(os.path.dirname(__file__), 'input.txt')
+with open(input_path, 'r') as file:
     data = file.read().strip().split('\n\n')
     data = [i.split('\n') for i in data]
 


### PR DESCRIPTION
## Summary
- make Day 1 scripts load `input.txt` relative to their own directory

## Testing
- `python 'Day 1/Part1.py'`
- `python 'Day 1/Part2.py'`


------
https://chatgpt.com/codex/tasks/task_e_684c1fb8ba4c83309ccbf279ab1ce67b